### PR TITLE
Add additional supplementary dataset

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ def get_sds_data(
     guid_filename_map = {
         "c067f6de-6d64-42b1-8b02-431a3486c178": "supplementary_data",
         "693dc252-2e90-4412-bd9c-c4d953e36fcd": "supplementary_data_v2",
+        "9b418603-ba90-4c93-851a-f9cecfbda06f": "supplementary_data_v3",
     }
 
     if filename := guid_filename_map.get(str(dataset_id)):

--- a/mock_data/supplementary_data_v3.json
+++ b/mock_data/supplementary_data_v3.json
@@ -1,0 +1,183 @@
+{
+    "dataset_id": "9b418603-ba90-4c93-851a-f9cecfbda06f",
+    "survey_id": "123",
+    "data": {
+        "schema_version": "v1",
+        "identifier": "12346789012A",
+        "company_name": "Lidl",
+        "company_details": {
+            "telephone_number": "01174564561",
+            "email": "contact@lidl.org"
+        },
+        "note": {
+            "title": "Value of total sales",
+            "description": "Total value of goods sold",
+            "example": {
+                "title": "Includes",
+                "description": "Sales across all EU stores"
+            }
+        },
+        "total_uk_sales": 555000.00,
+        "incorporation_date": "1947-11-27",
+        "items": {
+            "products": [
+                {
+                    "identifier": "89929001",
+                    "name": "Articles and equipment for sports or outdoor games",
+                    "cn_codes": "2504 + 250610 + 2512 + 2519 + 2524",
+                    "guidance_include": {
+                        "title": "Include",
+                        "list": [
+                            "for children's playgrounds",
+                            "swimming pools and paddling pools"
+                        ]
+                    },
+                    "guidance_exclude": {
+                        "title": "Exclude",
+                        "list": [
+                            "sports holdalls, gloves, clothing of textile materials, footwear, protective eyewear, rackets, balls, skates",
+                            "for skiing, water sports, golf, fishing', for skiing, water sports, golf, fishing, table tennis, PE, gymnastics, athletics"
+                        ]
+                    },
+                    "value_sales": {
+                        "answer_code": "89929001",
+                        "label": "Value of sales"
+                    },
+                    "volume_sales": {
+                        "answer_code": "89929002",
+                        "label": "Volume of sales",
+                        "unit_label": "Tonnes"
+                    },
+                    "total_volume": {
+                        "answer_code": "89929005",
+                        "label": "Total volume produced",
+                        "unit_label": "Tonnes"
+                    }
+                },
+                {
+                    "identifier": "202346331",
+                    "name": "Kitchen Equipment",
+                    "cn_codes": "1028 + 5908 + 5910 + 591110 + 591120",
+                    "guidance_include": {
+                        "title": "Include",
+                        "list": [
+                            "pots and pans",
+                            "chopping board"
+                        ]
+                    },
+                    "guidance_exclude": {
+                        "title": "Exclude",
+                        "list": [
+                            "cutlery"
+                        ]
+                    },
+                    "value_sales": {
+                        "answer_code": "20234633101",
+                        "label": "Value of sales"
+                    },
+                    "volume_sales": {
+                        "answer_code": "20234633102",
+                        "label": "Volume of sales",
+                        "unit_label": "Kilogram"
+                    },
+                    "total_volume": {
+                        "answer_code": "20234633103",
+                        "label": "Total volume produced",
+                        "unit_label": "Kilogram"
+                    }
+                },
+                {
+                    "identifier": "246331",
+                    "name": "Groceries",
+                    "cn_codes": "1028 + 5908 + 5910 + 591110 + 591120",
+                    "guidance_include": {
+                        "title": "Include",
+                        "list": [
+                            "fruit and vegetables",
+                            "baked goods"
+                        ]
+                    },
+                    "value_sales": {
+                        "answer_code": "202101",
+                        "label": "Value of sales"
+                    },
+                    "volume_sales": {
+                        "answer_code": "202102",
+                        "label": "Volume of sales",
+                        "unit_label": "Kilogram"
+                    },
+                    "total_volume": {
+                        "answer_code": "202103",
+                        "label": "Total volume produced",
+                        "unit_label": "Kilogram"
+                    }
+                }
+            ],
+            "employees": [
+                {
+                    "identifier": "429001",
+                    "personal_details": {
+                        "forename": "Harry",
+                        "surname": "Potter",
+                        "address": {
+                            "postcode": "BS1 1AJ",
+                            "house_number": "12",
+                            "city": "Bristol"
+                        }
+                    },
+                    "employment_details": {
+                        "job_title": "Customer assistant",
+                        "start_date": "2020-01-01",
+                        "salary": {
+                            "payroll_number": "54345",
+                            "value": "25000",
+                            "currency": "GBP"
+                        }
+                    }
+                },
+                {
+                    "identifier": "529001",
+                    "personal_details": {
+                        "forename": "Bruce",
+                        "surname": "Wayne",
+                        "address": {
+                            "postcode": "BS1 1HJ",
+                            "house_number": "15",
+                            "city": "Bristol"
+                        }
+                    },
+                    "employment_details": {
+                        "job_title": "Customer assistant",
+                        "start_date": "2019-03-01",
+                        "salary": {
+                            "payroll_number": "4345",
+                            "value": "27000",
+                            "currency": "GBP"
+                        }
+                    }
+                },
+                {
+                    "identifier": "629011",
+                    "personal_details": {
+                        "forename": "Henry",
+                        "surname": "Green",
+                        "address": {
+                            "postcode": "BS1 1HR",
+                            "house_number": "11",
+                            "city": "Bristol"
+                        }
+                    },
+                    "employment_details": {
+                        "job_title": "Warehouse operative",
+                        "start_date": "2022-10-01",
+                        "salary": {
+                            "payroll_number": "28379",
+                            "value": "29000",
+                            "currency": "GBP"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/mock_data/supplementary_dataset_metadata_response.json
+++ b/mock_data/supplementary_dataset_metadata_response.json
@@ -22,5 +22,17 @@
         "sds_dataset_version": 1,
         "filename": "",
         "dataset_id": "693dc252-2e90-4412-bd9c-c4d953e36fcd"
+    },
+    {
+        "survey_id": "123",
+        "period_id": "202301",
+        "title": "Supplementary data v3",
+        "sds_schema_version": 1,
+        "sds_published_at": "2023-10-11T11:55:01Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": 1,
+        "filename": "",
+        "dataset_id": "9b418603-ba90-4c93-851a-f9cecfbda06f"
     }
 ]

--- a/mock_data/supplementary_dataset_metadata_response.json
+++ b/mock_data/supplementary_dataset_metadata_response.json
@@ -19,7 +19,7 @@
         "sds_published_at": "2023-07-01T11:25:01Z",
         "total_reporting_units": 2,
         "schema_version": "v1.0.0",
-        "sds_dataset_version": 1,
+        "sds_dataset_version": 2,
         "filename": "",
         "dataset_id": "693dc252-2e90-4412-bd9c-c4d953e36fcd"
     },
@@ -31,7 +31,7 @@
         "sds_published_at": "2023-10-11T11:55:01Z",
         "total_reporting_units": 2,
         "schema_version": "v1.0.0",
-        "sds_dataset_version": 1,
+        "sds_dataset_version": 3,
         "filename": "",
         "dataset_id": "9b418603-ba90-4c93-851a-f9cecfbda06f"
     }


### PR DESCRIPTION
### What is the context of this PR?
Whilst resolving the bug with section progress in [this runner PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/1224) it was noticed that when the number of employees changes and a repeating section question is enabled based off this list length, progress does not always update

This PR adds an additional employee to a 3rd dataset, so that functional testing of this bug is available.

### How to review
Check the dataset is valid (A diff between v2 and v3 should show only the new employee as the difference) 
Whilst running the mock locally, check the dataset is accessible in runner in the `test_supplementary_data` schema without error
