### PR TITLE
Add support for BRS

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "test": ["123"],
     "prodcom": ["014"],
     "bres": ["221"],
+    "brs": ["241"],
     "roofing_tiles_slate": [
         "068",  # Roofing tiles
         "071",  # Slate

--- a/scripts/load_mock_unit_data.sh
+++ b/scripts/load_mock_unit_data.sh
@@ -4,8 +4,8 @@ set -e
 
 REPO_NAME="sds-schema-definitions"
 
-DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/add-brs-schema-definition.zip"
-DOWNLOAD_NAME="${REPO_NAME}-add-brs-schema-definition"
+DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/main.zip"
+DOWNLOAD_NAME="${REPO_NAME}-main"
 
 echo "Fetching ${DOWNLOAD_URL}"
 

--- a/scripts/load_mock_unit_data.sh
+++ b/scripts/load_mock_unit_data.sh
@@ -4,8 +4,8 @@ set -e
 
 REPO_NAME="sds-schema-definitions"
 
-DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/main.zip"
-DOWNLOAD_NAME="${REPO_NAME}-main"
+DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/add-brs-schema-definition.zip"
+DOWNLOAD_NAME="${REPO_NAME}-add-brs-schema-definition"
 
 echo "Fetching ${DOWNLOAD_URL}"
 


### PR DESCRIPTION
### What is the context of this PR?
The Mock SDS has been updated to support BRS by updating the schemas it retrieves from the `sds-schema-definitions` repo. The change includes adding the `survey_id` in order for the mock data to be loaded correctly in Runner.

### How to review
- **Note** This may be tougher due to the fact that BRS schemas aren't available so we can't test if they open
- Check the changes made are correct
- Check the survey_id is correct
- Make sure the correct mock unit data loads when running the relevant Make command (`make load-mock-unit-data`)