### PR TITLE
Split surveys into individual folders

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,14 +35,10 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "prodcom": ["014"],
     "bres": ["221"],
     "brs": ["241"],
-    "roofing_tiles_slate": [
-        "068",  # Roofing tiles
-        "071",  # Slate
-    ],
-    "sand_and_gravel": [
-        "066",  # Sand and & Gravel (Land Won)
-        "076",  # Sand & Gravel (Marine Dredged)
-    ],
+    "slate": ["071"],
+    "roofing_tiles": ["068"],
+    "sand_and_gravel_land_won": ["066"],
+    "sand_and_gravel_marine_dredged": ["076",],
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -38,9 +38,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "slate": ["071"],
     "roofing_tiles": ["068"],
     "sand_and_gravel_land_won": ["066"],
-    "sand_and_gravel_marine_dredged": [
-        "076",
-    ],
+    "sand_and_gravel_marine_dredged": ["076"],
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -38,7 +38,9 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "slate": ["071"],
     "roofing_tiles": ["068"],
     "sand_and_gravel_land_won": ["066"],
-    "sand_and_gravel_marine_dredged": ["076",],
+    "sand_and_gravel_marine_dredged": [
+        "076",
+    ],
 }
 
 


### PR DESCRIPTION
### What is the context of this PR?
Because [sds-schema-definitions](https://github.com/ONSdigital/sds-schema-definitions/pull/12) needed updating in this PR and the slate, roofing tiles, sand and gravel land and marine needed splitting out into individual folders so this repo also needed updating because we have some hardcoded values

### How to review
Compare changes with https://github.com/ONSdigital/sds-schema-definitions/pull/12 and make sure changes are reflected correctly
