### PR TITLE
Add support for SPPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "sand_and_gravel_land_won": ["066"],
     "sand_and_gravel_marine_dredged": ["076"],
     "ppi": ["132"],
+    "sppi": ["061"],
 }
 
 


### PR DESCRIPTION
### What is the context of this PR?
The Mock SDS has been updated to support SPPI by updating the schemas it retrieves from the `sds-schema-definitions` repo. The change includes adding the `survey_id` in order for the mock data to be loaded correctly in Runner.

### How to review
- **Note** This may be tougher due to the fact that SPPI schemas aren't available so we can't test if they open
- Check the changes made are correct
- Check the survey_id is correct
- Make sure the correct mock unit data loads when running the relevant Make command (`make load-mock-unit-data`)
