### PR TITLE
Add support for EPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "sand_and_gravel_marine_dredged": ["076"],
     "ppi": ["132"],
     "sppi": ["061"],
+    "epi": ["133"]
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -41,7 +41,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "sand_and_gravel_marine_dredged": ["076"],
     "ppi": ["132"],
     "sppi": ["061"],
-    "epi": ["133"]
+    "epi": ["133"],
 }
 
 

--- a/scripts/load_mock_unit_data.sh
+++ b/scripts/load_mock_unit_data.sh
@@ -4,8 +4,8 @@ set -e
 
 REPO_NAME="sds-schema-definitions"
 
-DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/main.zip"
-DOWNLOAD_NAME="${REPO_NAME}-main"
+DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/add-epi-schema-definition.zip"
+DOWNLOAD_NAME="${REPO_NAME}-add-epi-schema-definition"
 
 echo "Fetching ${DOWNLOAD_URL}"
 

--- a/scripts/load_mock_unit_data.sh
+++ b/scripts/load_mock_unit_data.sh
@@ -4,8 +4,8 @@ set -e
 
 REPO_NAME="sds-schema-definitions"
 
-DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/add-epi-schema-definition.zip"
-DOWNLOAD_NAME="${REPO_NAME}-add-epi-schema-definition"
+DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/main.zip"
+DOWNLOAD_NAME="${REPO_NAME}-main"
 
 echo "Fetching ${DOWNLOAD_URL}"
 


### PR DESCRIPTION
### What is the context of this PR?
The Mock SDS has been updated to support EPI by updating the schemas it retrieves from the `sds-schema-definitions` repo. 

### How to review
- **Note** This may be tougher due to the fact that EPI schemas aren't available so we can't test if they open
- Check the changes made are correct
- Check the survey_id is correct
- Make sure the correct mock data loads when running the relevant Make command (`make load-mock-unit-data`)
