### PR TITLE
add ipi support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "sand_and_gravel_marine_dredged": ["076"],
     "ppi": ["132"],
     "sppi": ["061"],
+    "ipi": ["156"]
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -41,7 +41,7 @@ MOCK_DATA_PATHS_BY_SURVEY_ID = {
     "sand_and_gravel_marine_dredged": ["076"],
     "ppi": ["132"],
     "sppi": ["061"],
-    "ipi": ["156"]
+    "ipi": ["156"],
 }
 
 


### PR DESCRIPTION
### What is the context of this PR?
The Mock SDS has been updated to support IPI by updating the schemas it retrieves from the sds-schema-definitions repo.

### How to review
Describe the steps required to test the changes (include screenshots if appropriate).
- Note This may be tougher due to the fact that IPI schemas aren't available, so we can't test if they open
- Check the survey_id is correct
- change the download_url and download_name in scripts/load_mock_unit_data.sh to test ipi example changes.
DOWNLOAD_URL="https://github.com/onsdigital/${REPO_NAME}/archive/refs/heads/add-ipi-schema-definition.zip"
DOWNLOAD_NAME="${REPO_NAME}-add-ipi-schema-definition"

