### PR TITLE
EQS-1008: Update mock SDS endpoints to new URL format

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -83,7 +83,9 @@ class UnitData(BaseModel):
 
 
 @app.get("/datasets/{dataset_id}/unit-data/{identifier}")
-def get_unit_data(dataset_id: UUID, identifier: str = FastAPIPath(min_length=1)) -> UnitData:
+def get_unit_data(
+    dataset_id: UUID, identifier: str = FastAPIPath(min_length=1)
+) -> UnitData:
     # The mock current does not make use of identifier
     """Return an encrypted map of mocked unit data for the given dataset_id"""
     _, dataset_to_unit_data_map = load_mock_data()

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import uvicorn
 import yaml
-from fastapi import FastAPI, Query, HTTPException
+from fastapi import FastAPI, Query, HTTPException, Path as FastAPIPath
 from pydantic import BaseModel
 from sdc.crypto.jwe_helper import JWEHelper
 from sdc.crypto.key_store import KeyStore
@@ -82,8 +82,8 @@ class UnitData(BaseModel):
     data: str
 
 
-@app.get("/v1/unit_data")
-def get_unit_data(dataset_id: UUID, identifier: str = Query(min_length=1)) -> UnitData:
+@app.get("/datasets/{dataset_id}/unit-data/{identifier}")
+def get_unit_data(dataset_id: UUID, identifier: str = FastAPIPath(min_length=1)) -> UnitData:
     # The mock current does not make use of identifier
     """Return an encrypted map of mocked unit data for the given dataset_id"""
     _, dataset_to_unit_data_map = load_mock_data()
@@ -94,7 +94,7 @@ def get_unit_data(dataset_id: UUID, identifier: str = Query(min_length=1)) -> Un
     raise HTTPException(status_code=404)
 
 
-@app.get("/v1/dataset_metadata")
+@app.get("/datasets/metadata")
 def get_dataset_metadata(
     survey_id: str = Query(min_length=1), period_id: str = Query(min_length=1)
 ) -> list[DatasetMetadata]:

--- a/app/test_app.py
+++ b/app/test_app.py
@@ -17,36 +17,40 @@ client = TestClient(app)
 
 
 def test_get_sds_unit_data_found():
+    dataset_id ="203b2f9d-c500-8175-98db-86ffcfdccfa3"
+    identifier = "12345678901"
+
     response = client.get(
-        "/v1/unit_data",
-        params={
-            "dataset_id": "203b2f9d-c500-8175-98db-86ffcfdccfa3",
-            "identifier": "12345678901",
-        },
+        f"/datasets/{dataset_id}/unit-data/{identifier}",
     )
+
     assert response.status_code == 200
     assert "data" in response.json()
 
 
 def test_get_sds_unit_data_not_found():
+    dataset_id = "00000000-0000-0000-0000-000000000000"
+    identifier = "12345678901"
+
     response = client.get(
-        "/v1/unit_data",
-        params={
-            "dataset_id": "00000000-0000-0000-0000-000000000000",
-            "identifier": "12345678901",
-        },
+        f"/datasets/{dataset_id}/unit-data/{identifier}",
     )
+
     assert response.status_code == 404
 
 
 def test_get_sds_unit_data_invalid_uuid():
-    response = client.get("/v1/unit_data", params={"dataset_id": "invalid_uuid"})
+    dataset_id = "invalid_uuid"
+    identifier = "12345678901"
+
+    response = client.get(f"/datasets/{dataset_id}/unit-data/{identifier}")
+
     assert response.status_code == 422
 
 
 def test_get_sds_dataset_metadata_ids_found():
     response = client.get(
-        "/v1/dataset_metadata", params={"survey_id": "123", "period_id": "202301"}
+        "/datasets/metadata", params={"survey_id": "123", "period_id": "202301"}
     )
     assert response.status_code == 200
     assert isinstance(response.json(), list)
@@ -54,7 +58,7 @@ def test_get_sds_dataset_metadata_ids_found():
 
 def test_get_sds_dataset_metadata_ids_not_found():
     response = client.get(
-        "/v1/dataset_metadata",
+        "/datasets/metadata",
         params={
             "survey_id": "non_existent_survey_id",
             "period_id": "non_existent_period_id",

--- a/app/test_app.py
+++ b/app/test_app.py
@@ -17,7 +17,7 @@ client = TestClient(app)
 
 
 def test_get_sds_unit_data_found():
-    dataset_id ="203b2f9d-c500-8175-98db-86ffcfdccfa3"
+    dataset_id = "203b2f9d-c500-8175-98db-86ffcfdccfa3"
     identifier = "12345678901"
 
     response = client.get(


### PR DESCRIPTION
### What is the context of this PR?
Updates the mock SDS service to support the new SDS endpoint format

- Unit data endpoint changed to /datasets/{dataset_id}/unit-data/{identifier} 
- dataset metadata endpoint remains query based params but name changed datasets/metadata?survey_id=...&period_id=...

### How to review

- run mock sds test
- you can check if the new endpoints return data like:
    - curl -i "http://localhost:5003/datasets/metadata?survey_id=123&period_id=201605
    - curl -i "http://localhost:5003/datasets/203b2f9d-c500-8175-98db-86ffcfdccfa3/unit-data/12345678901"
